### PR TITLE
Replace link to Mark Sample reading with Google cached version

### DIFF
--- a/courses/digital-futures-of-history/schedule.md
+++ b/courses/digital-futures-of-history/schedule.md
@@ -30,7 +30,7 @@ Lisa Spiro, ["This Is Why We Fight": Defining the Values of the Digital Humaniti
 ### Wednesday
 Stephen Ramsay, [DH Types One and Two](http://stephenramsay.us/2013/05/03/dh-one-and-two/).
 
-Mark Sample, [The Digital Humanities Is Not About Building, It’s About Sharing](http://www.samplereality.com/2011/05/25/the-digital-humanities-is-not-about-building-its-about-sharing/).
+Mark Sample, [The Digital Humanities Is Not About Building, It’s About Sharing](http://webcache.googleusercontent.com/search?q=cache:IyRYK7RWT8cJ:www.samplereality.com/2011/05/25/the-digital-humanities-is-not-about-building-its-about-sharing/+&cd=1&hl=en&ct=clnk&gl=us).
 
 
 ## 3: What is History?

--- a/courses/digital-methods/schedule.md
+++ b/courses/digital-methods/schedule.md
@@ -25,7 +25,7 @@ Julia Flanders, [The Productive Unease of 21st-century Digital Scholarship](http
 
 Stephen Ramsay, [DH Types One and Two](http://stephenramsay.us/2013/05/03/dh-one-and-two/).
 
-Mark Sample, [The Digital Humanities Is Not About Building, It’s About Sharing](http://www.samplereality.com/2011/05/25/the-digital-humanities-is-not-about-building-its-about-sharing/).
+Mark Sample, [The Digital Humanities Is Not About Building, It’s About Sharing](http://webcache.googleusercontent.com/search?q=cache:IyRYK7RWT8cJ:www.samplereality.com/2011/05/25/the-digital-humanities-is-not-about-building-its-about-sharing/+&cd=1&hl=en&ct=clnk&gl=us).
 
 Lisa Spiro, ["This Is Why We Fight": Defining the Values of the Digital Humanities](http://dhdebates.gc.cuny.edu/debates/text/13)
 


### PR DESCRIPTION
This page worked last week, but when I tried to revisit it today, the whole site seems compromised or broken, with just a download file prompt. This google cache link works for me, but you may want to use a saved version from your Zotero library instead.